### PR TITLE
workaround for a bug where $!data becomes a type object Blob

### DIFF
--- a/lib/IO/Blob.pm6
+++ b/lib/IO/Blob.pm6
@@ -9,7 +9,7 @@ constant SPACE = " ".encode;
 
 has Int $!pos = 0;
 has Int $!ins = 1;
-has Blob $.data is rw;
+has Blob $.data is rw = Buf.new;
 has Bool $!is_closed = False;
 has Str $.nl is rw = "\n";
 has $.path;


### PR DESCRIPTION
Please look at https://travis-ci.org/shoichikaji/Frinfon/builds/86193195

Sometimes IO::Blob's $!data attribute leaves as a type object Blob.
Actually I have no idea why $!data sometimes be a type object. But it happens.

Then `IO::Blob.data.any-method` fails.

This PR adds a workaround for this.
