### PR TITLE
Define seek(int, SeekType) interface instead of seek(int, int)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ install:
   - rakudobrew build-panda
   - panda --notests installdeps .
 script:
-  - perl6 -MPanda::Builder -e 'Panda::Builder.new.build($*CWD)'
-  - PERL6LIB=$PWD/blib/lib prove -e perl6 -r t/
+  - prove -e 'perl6 -Ilib' -rv t/
 sudo: false
 

--- a/lib/IO/Blob.pm6
+++ b/lib/IO/Blob.pm6
@@ -165,15 +165,14 @@ method write(IO::Blob:D: Blob:D $buf) returns Bool {
     return True;
 }
 
-method seek(IO::Blob:D: int $offset, int $whence) returns Bool {
+method seek(IO::Blob:D: int $offset, SeekType:D $whence = SeekFromBeginning) returns Bool {
     my $eofpos = $.data.elems;
 
     # Seek:
     given $whence {
-        when 0 { $!pos = $offset } # SEEK_SET
-        when 1 { $!pos += $offset } # SEEK_CUR
-        when 2 { $!pos = $eofpos + $offset } #SEEK_END
-        default { die "bad seek whence ($whence)" }
+        when SeekFromBeginning { $!pos = $offset }
+        when SeekFromCurrent   { $!pos += $offset }
+        when SeekFromEnd       { $!pos = $eofpos + $offset }
     }
 
     # Fixup
@@ -346,19 +345,19 @@ Binary reading; reads and returns C<$bytes> bytes from the Blob.
 
 Binary writing; writes $buf to the Blob.
 
-=head2 seek(IO::Blob:D: int $offset, int $whence)
+=head2 seek(IO::Blob:D: int $offset, SeekType:D $whence = SeekFromBeginning)
 
 Move the pointer (that is the position at which any subsequent read or write operations will begin,) to the byte position specified by C<$offset> relative to the location specified by C<$whence> which may be one of:
 
-=item 0
+=item SeekFromBeginning
 
 The beginning of the file.
 
-=item 1
+=item SeekFromCurrent
 
 The current position in the file.
 
-=item 2
+=item SeekFromEnd
 
 The end of the file.
 

--- a/t/010_basic.t
+++ b/t/010_basic.t
@@ -169,15 +169,18 @@ subtest {
     is $io.read(TEXT.chars), TEXT.encode;
     is $io.read(TEXT.chars), "".encode;
 
-    $io.seek(0, 0);
+    $io.seek(0);
     is $io.read(TEXT.chars), TEXT.encode;
 
-    $io.seek(0, 0);
-    $io.seek(6, 1);
+    $io.seek(0, SeekFromBeginning);
+    is $io.read(TEXT.chars), TEXT.encode;
+
+    $io.seek(0, SeekFromBeginning);
+    $io.seek(6, SeekFromCurrent);
     is $io.read(10), "line2\nline".encode;
 
     is $io.eof(), False;
-    $io.seek(0, 2);
+    $io.seek(0, SeekFromEnd);
     is $io.eof(), True;
 }, 'Test for seek() and read()';
 
@@ -189,7 +192,7 @@ subtest {
     # is $io.ins(), 5;
     is $io.eof(), True;
 
-    $io.seek(0, 0);
+    $io.seek(0, SeekFromBeginning);
     is $io.read(TEXT.chars + 12), "line1\nline2\nline3\nline4line5line6".encode;
     is $io.data(), "line1\nline2\nline3\nline4line5line6".encode;
 }, 'Test for print() and seek()';
@@ -202,7 +205,7 @@ subtest {
     # is $io.ins(), 5;
     is $io.eof(), True;
 
-    $io.seek(0, 0);
+    $io.seek(0, SeekFromBeginning);
     is $io.read(TEXT.chars + 12), "line1\nline2\nline3\nline4line5".encode;
 }, 'Test for write() and seek()';
 
@@ -213,7 +216,7 @@ subtest {
         is $io.slurp-rest(bin => True), "line1\nline2\nline3\nline4".encode;
         is $io.slurp-rest(bin => True), Buf.new();
 
-        $io.seek(6, 0);
+        $io.seek(6, SeekFromBeginning);
         is $io.slurp-rest(bin => True), "line2\nline3\nline4".encode;
     }, 'bin';
 
@@ -223,7 +226,7 @@ subtest {
         is $io.slurp-rest(enc => 'utf8'), "line1\nline2\nline3\nline4";
         is $io.slurp-rest(enc => 'utf8'), "";
 
-        $io.seek(6, 0);
+        $io.seek(6, SeekFromBeginning);
         is $io.slurp-rest(enc => 'utf8'), "line2\nline3\nline4";
     }, 'with encode';
 
@@ -233,7 +236,7 @@ subtest {
         is $io.slurp-rest(), "line1\nline2\nline3\nline4";
         is $io.slurp-rest(), "";
 
-        $io.seek(6, 0);
+        $io.seek(6, SeekFromBeginning);
         is $io.slurp-rest(), "line2\nline3\nline4";
     }, 'with out encode';
 }, 'Test for slurp-rest';


### PR DESCRIPTION
Because IO::Handle::seek(int, int) was deprecated and removed from
latest version. IO::Blob should have seek interface same as IO::Handle.
