### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
   "name" : "IO::Blob",
+  "license" : "Artistic-2.0",
   "source-url" : "git://github.com/moznion/p6-IO-Blob.git",
   "perl" : "6",
   "build-depends" : [ ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license