### PR TITLE
Set version number to 0.0.1

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,17 +1,19 @@
 {
-  "name" : "IO::Blob",
-  "license" : "Artistic-2.0",
-  "source-url" : "git://github.com/moznion/p6-IO-Blob.git",
-  "perl" : "6",
+  "authors" : [
+    "moznion"
+  ],
   "build-depends" : [ ],
+  "depends" : [ ],
+  "description" : "IO:: interface for reading/writing a Blob",
+  "license" : "Artistic-2.0",
+  "name" : "IO::Blob",
+  "perl" : "6",
   "provides" : {
     "IO::Blob" : "lib/IO/Blob.pm6"
   },
-  "depends" : [ ],
-  "description" : "IO:: interface for reading/writing a Blob",
+  "resources" : [ ],
+  "source-url" : "git://github.com/moznion/p6-IO-Blob.git",
+  "tags" : [ ],
   "test-depends" : [ ],
-  "version" : "*",
-  "authors" : [
-    "moznion"
-  ]
+  "version" : "0.0.1"
 }

--- a/lib/IO/Blob.pm6
+++ b/lib/IO/Blob.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-unit class IO::Blob is IO::Handle;
+unit class IO::Blob:ver<0.0.1> is IO::Handle;
 
 constant EMPTY = "".encode;
 constant LF = "\n".encode;


### PR DESCRIPTION
HTTP::Server::Tiny want to depend on the latest version of p6-IO-Blob. But IO::Blob doesn't provide the version number. This p-r fixes this issue.